### PR TITLE
Add Virtual Threads Tests, Fix Executor Shutdown Leak, and Optimize Predecessor Lookup

### DIFF
--- a/src/main/java/dev/shaaf/jgraphlet/CacheKey.java
+++ b/src/main/java/dev/shaaf/jgraphlet/CacheKey.java
@@ -1,5 +1,7 @@
 package dev.shaaf.jgraphlet;
 
+import java.util.*;
+
 /**
  * Cache key used to uniquely identify the output of a task for a given input.
  *
@@ -7,4 +9,19 @@ package dev.shaaf.jgraphlet;
  * @param input    the input provided to that task
  */
 public record CacheKey(String taskName, Object input) {
+  public CacheKey {
+    Objects.requireNonNull(taskName, "taskName");
+    input = normalize(input); // snapshot for stable equals/hashCode
+  }
+  private static Object normalize(Object o) {
+    if (o == null) return null;
+    if (o instanceof Map<?, ?> m) {
+      // preserve iteration order to keep equals/hash stable
+      var copy = new LinkedHashMap<>(m);
+      return Map.copyOf(copy);
+    }
+    if (o instanceof List<?> l) return List.copyOf(l);
+    if (o instanceof Set<?> s)  return Set.copyOf(s);
+    return o; // assume immutable or stable
+  }
 }

--- a/src/test/java/dev/shaaf/jgraphlet/TaskPipelinePerformanceTest.java
+++ b/src/test/java/dev/shaaf/jgraphlet/TaskPipelinePerformanceTest.java
@@ -1,0 +1,180 @@
+package dev.shaaf.jgraphlet;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Performance tests for TaskPipeline optimizations.
+ * Demonstrates the performance improvements from using reverse adjacency map.
+ */
+class TaskPipelinePerformanceTest {
+
+    @Test
+    void shouldHandleLargeFanInGraphEfficiently() {
+        // This test creates a large fan-in graph to test the O(1) predecessor lookup
+        // Before optimization: O(n*m) where n = number of tasks, m = average connections per task
+        // After optimization: O(1) lookup time
+        
+        TaskPipeline pipeline = new TaskPipeline();
+        
+        // Create a simple task for testing
+        Task<String, String> simpleTask = (input, context) -> 
+            CompletableFuture.completedFuture(input + "-processed");
+        
+        Task<java.util.Map<String, Object>, String> aggregatorTask = (inputs, context) ->
+            CompletableFuture.completedFuture("Aggregated " + inputs.size() + " inputs");
+        
+        // Create a large fan-in scenario: many tasks feeding into one
+        int numFeederTasks = 100;
+        
+        // Add the aggregator task
+        pipeline.addTask("aggregator", aggregatorTask);
+        
+        // Add many feeder tasks and connect them all to the aggregator
+        Instant startSetup = Instant.now();
+        for (int i = 0; i < numFeederTasks; i++) {
+            String taskName = "feeder" + i;
+            pipeline.addTask(taskName, simpleTask);
+            pipeline.connect(taskName, "aggregator");
+        }
+        Duration setupTime = Duration.between(startSetup, Instant.now());
+        
+        // Run the pipeline - this will call findPredecessorsFor many times
+        Instant startRun = Instant.now();
+        CompletableFuture<Object> result = pipeline.run("test-input");
+        Object finalResult = result.join();
+        Duration runTime = Duration.between(startRun, Instant.now());
+        
+        // Assert
+        assertNotNull(finalResult);
+        assertEquals("Aggregated " + numFeederTasks + " inputs", finalResult);
+        
+        // Performance assertions
+        assertTrue(setupTime.toMillis() < 100, 
+            "Setup should be fast even with " + numFeederTasks + " connections (took: " + setupTime.toMillis() + "ms)");
+        assertTrue(runTime.toMillis() < 500, 
+            "Execution should be fast with O(1) predecessor lookups (took: " + runTime.toMillis() + "ms)");
+        
+        System.out.println("✓ Large fan-in graph (" + numFeederTasks + " tasks) setup: " + 
+                         setupTime.toMillis() + "ms, execution: " + runTime.toMillis() + "ms");
+        
+        pipeline.shutdown();
+    }
+    
+    @Test
+    void shouldHandleComplexDiamondGraphEfficiently() {
+        // Test a diamond-shaped graph with multiple paths
+        // This tests that the reverse graph correctly maintains multiple predecessors
+        
+        TaskPipeline pipeline = new TaskPipeline();
+        
+        Task<String, String> transformTask = (input, context) -> 
+            CompletableFuture.completedFuture(input + "-transformed");
+        
+        Task<java.util.Map<String, Object>, String> mergeTask = (inputs, context) -> {
+            String path1 = (String) inputs.get("path1");
+            String path2 = (String) inputs.get("path2");
+            return CompletableFuture.completedFuture(path1 + " & " + path2);
+        };
+        
+        // Create diamond shape: start -> path1 & path2 -> end
+        pipeline.addTask("start", transformTask)
+               .addTask("path1", transformTask)
+               .addTask("path2", transformTask)
+               .addTask("end", mergeTask);
+        
+        pipeline.connect("start", "path1")
+               .connect("start", "path2")
+               .connect("path1", "end")
+               .connect("path2", "end");
+        
+        // Run and verify
+        String result = (String) pipeline.run("input").join();
+        
+        assertEquals("input-transformed-transformed & input-transformed-transformed", result);
+        System.out.println("✓ Diamond graph executed correctly with optimized predecessor lookups");
+        
+        pipeline.shutdown();
+    }
+    
+    @Test
+    void shouldScaleWellWithManyTasks() {
+        // Test scalability with a large number of tasks in a chain
+        TaskPipeline pipeline = new TaskPipeline();
+        
+        Task<Integer, Integer> incrementTask = (input, context) -> 
+            CompletableFuture.completedFuture(input + 1);
+        
+        int chainLength = 50;
+        
+        // Build a long chain of tasks
+        Instant startSetup = Instant.now();
+        pipeline.add("task0", incrementTask);
+        for (int i = 1; i < chainLength; i++) {
+            pipeline.then("task" + i, incrementTask);
+        }
+        Duration setupTime = Duration.between(startSetup, Instant.now());
+        
+        // Execute the chain
+        Instant startRun = Instant.now();
+        Integer result = (Integer) pipeline.run(0).join();
+        Duration runTime = Duration.between(startRun, Instant.now());
+        
+        // Verify result
+        assertEquals(chainLength, result, "Should increment " + chainLength + " times");
+        
+        // Performance checks
+        assertTrue(setupTime.toMillis() < 50, 
+            "Chain setup should be fast (took: " + setupTime.toMillis() + "ms)");
+        assertTrue(runTime.toMillis() < 200, 
+            "Chain execution should be efficient (took: " + runTime.toMillis() + "ms)");
+        
+        System.out.println("✓ Chain of " + chainLength + " tasks - setup: " + 
+                         setupTime.toMillis() + "ms, execution: " + runTime.toMillis() + "ms");
+        
+        pipeline.shutdown();
+    }
+    
+    @Test
+    void shouldMaintainCorrectReverseGraphAfterMultipleConnections() {
+        // Test that reverse graph is correctly maintained with complex connections
+        TaskPipeline pipeline = new TaskPipeline();
+        
+        Task<String, String> task = (input, context) -> 
+            CompletableFuture.completedFuture(input);
+        
+        Task<java.util.Map<String, Object>, String> collectTask = (inputs, context) ->
+            CompletableFuture.completedFuture("Collected: " + inputs.keySet());
+        
+        // Create a complex graph structure
+        pipeline.addTask("A", task)
+               .addTask("B", task)
+               .addTask("C", task)
+               .addTask("D", collectTask)
+               .addTask("E", collectTask);
+        
+        // Multiple connections
+        pipeline.connect("A", "D")  // A -> D
+               .connect("B", "D")    // B -> D
+               .connect("A", "E")    // A -> E
+               .connect("C", "E");   // C -> E
+        
+        // D should have predecessors: A, B
+        // E should have predecessors: A, C
+        
+        // Run pipeline - this will use findPredecessorsFor internally
+        CompletableFuture<Object> futureD = pipeline.run("test");
+        
+        // The execution should work correctly with the optimized reverse graph
+        assertDoesNotThrow(() -> futureD.join());
+        
+        System.out.println("✓ Complex graph with multiple connections handled correctly");
+        
+        pipeline.shutdown();
+    }
+}

--- a/src/test/java/dev/shaaf/jgraphlet/TaskPipelineShutdownTest.java
+++ b/src/test/java/dev/shaaf/jgraphlet/TaskPipelineShutdownTest.java
@@ -1,0 +1,202 @@
+package dev.shaaf.jgraphlet;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskPipelineShutdownTest {
+
+    @Test
+    void shouldShutdownGracefullyWithTimeout() throws InterruptedException {
+        // Arrange: Create pipeline with reasonable timeout
+        TaskPipeline pipeline = new TaskPipeline(5, 2);
+        
+        CountDownLatch taskStarted = new CountDownLatch(1);
+        CountDownLatch allowCompletion = new CountDownLatch(1);
+        AtomicBoolean taskCompleted = new AtomicBoolean(false);
+        
+        // Create a task that waits for signal before completing
+        Task<String, String> controllableTask = (input, context) -> {
+            taskStarted.countDown();
+            try {
+                // Wait for signal to complete
+                if (allowCompletion.await(10, TimeUnit.SECONDS)) {
+                    taskCompleted.set(true);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return CompletableFuture.completedFuture("completed");
+        };
+        
+        // Act
+        pipeline.add("controllableTask", controllableTask);
+        CompletableFuture<Object> future = pipeline.run("input");
+        
+        // Wait for task to start
+        assertTrue(taskStarted.await(2, TimeUnit.SECONDS), "Task should have started");
+        
+        // Signal task to complete
+        allowCompletion.countDown();
+        
+        // Wait for completion
+        future.join();
+        
+        // Shutdown should complete quickly since task is done
+        long startTime = System.currentTimeMillis();
+        pipeline.shutdown();
+        long shutdownTime = System.currentTimeMillis() - startTime;
+        
+        // Assert
+        assertTrue(taskCompleted.get(), "Task should have completed");
+        assertTrue(shutdownTime < 1000, "Shutdown should be quick when no tasks running");
+    }
+    
+    @Test
+    void shouldNotShutdownExternalExecutor() throws InterruptedException {
+        // Arrange: Create external executor
+        var externalExecutor = java.util.concurrent.Executors.newFixedThreadPool(2);
+        
+        try {
+            TaskPipeline pipeline = new TaskPipeline(externalExecutor);
+            
+            Task<String, String> task = (input, context) -> 
+                CompletableFuture.completedFuture("result");
+            
+            // Act
+            pipeline.add("task", task);
+            pipeline.run("input").join();
+            pipeline.shutdown();
+            
+            // Assert - external executor should still be running
+            assertFalse(externalExecutor.isShutdown(), 
+                "External executor should not be shut down by pipeline");
+            
+        } finally {
+            // Clean up
+            externalExecutor.shutdown();
+            externalExecutor.awaitTermination(1, TimeUnit.SECONDS);
+        }
+    }
+    
+    @Test
+    void shouldHandleMultipleShutdownCallsGracefully() {
+        // Arrange
+        TaskPipeline pipeline = new TaskPipeline();
+        
+        Task<String, String> simpleTask = (input, context) -> 
+            CompletableFuture.completedFuture("done");
+        
+        // Act
+        pipeline.add("simpleTask", simpleTask);
+        Object result = pipeline.run("input").join();
+        
+        // Multiple shutdown calls should not cause issues
+        pipeline.shutdown();
+        pipeline.shutdown();
+        pipeline.close();
+        
+        // Assert
+        assertEquals("done", result);
+        // No exceptions should be thrown
+    }
+    
+    @Test  
+    void shouldUseCustomTimeoutValues() throws InterruptedException {
+        // This test verifies that custom timeout values are properly used
+        // We create a pipeline with short timeouts and verify the shutdown behavior
+        
+        // Arrange: Create pipeline with custom timeouts
+        long gracefulTimeout = 2; // 2 seconds for graceful shutdown
+        long forcedTimeout = 1;   // 1 second for forced shutdown
+        TaskPipeline pipeline = new TaskPipeline(gracefulTimeout, forcedTimeout);
+        
+        // Create a simple task that completes quickly
+        Task<String, String> quickTask = (input, context) -> 
+            CompletableFuture.completedFuture("done quickly");
+        
+        // Act
+        pipeline.add("quickTask", quickTask);
+        Object result = pipeline.run("input").join();
+        
+        // Measure shutdown time - should be very quick since no tasks are running
+        long startTime = System.currentTimeMillis();
+        pipeline.shutdown();
+        long shutdownTime = System.currentTimeMillis() - startTime;
+        
+        // Assert
+        assertEquals("done quickly", result);
+        // Shutdown should be nearly instant when no tasks are running
+        assertTrue(shutdownTime < 500, "Shutdown should be quick when no tasks are running");
+        
+        // Verify we can create another pipeline with different timeouts
+        TaskPipeline pipeline2 = new TaskPipeline(10, 5);
+        pipeline2.add("task", quickTask);
+        pipeline2.run("test").join();
+        pipeline2.shutdown();
+        // No exception should be thrown
+    }
+    
+    @Test
+    void shouldCleanupResourcesWithTryWithResources() throws Exception {
+        String result;
+        
+        // Use try-with-resources to ensure automatic cleanup
+        try (TaskPipeline pipeline = new TaskPipeline()) {
+            Task<String, String> task = (input, context) -> 
+                CompletableFuture.completedFuture(input.toUpperCase());
+            
+            pipeline.add("upperCase", task);
+            result = (String) pipeline.run("hello").join();
+        } // Pipeline.close() called automatically here
+        
+        // Assert
+        assertEquals("HELLO", result);
+        // Pipeline resources should be cleaned up automatically
+    }
+    
+    @Test
+    void shouldHandleShutdownNowCorrectly() {
+        // Arrange
+        TaskPipeline pipeline = new TaskPipeline();
+        
+        CountDownLatch taskStarted = new CountDownLatch(1);
+        AtomicBoolean taskInterrupted = new AtomicBoolean(false);
+        
+        Task<String, String> longTask = (input, context) -> 
+            CompletableFuture.supplyAsync(() -> {
+                taskStarted.countDown();
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    taskInterrupted.set(true);
+                    Thread.currentThread().interrupt();
+                }
+                return "should be interrupted";
+            });
+        
+        // Act
+        pipeline.add("longTask", longTask);
+        pipeline.run("input"); // Start but don't wait
+        
+        try {
+            taskStarted.await(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            fail("Test interrupted");
+        }
+        
+        // Force immediate shutdown
+        pipeline.shutdownNow();
+        
+        // Assert - task should be interrupted
+        // Note: The interruption happens in the ForkJoinPool threads
+        // We can't guarantee the task sees the interruption immediately
+        // but shutdownNow() should have been called
+        assertNotNull(pipeline); // Pipeline should still be valid after shutdownNow
+    }
+}

--- a/src/test/java/dev/shaaf/jgraphlet/TaskPipelineTest.java
+++ b/src/test/java/dev/shaaf/jgraphlet/TaskPipelineTest.java
@@ -86,7 +86,11 @@ class TaskPipelineTest {
         try {
             var field = TaskPipeline.class.getDeclaredField("lastAddedTaskName");
             field.setAccessible(true);
-            String lastAddedTaskName = (String) field.get(pipeline);
+            // Now lastAddedTaskName is an AtomicReference<String>
+            @SuppressWarnings("unchecked")
+            java.util.concurrent.atomic.AtomicReference<String> atomicRef = 
+                (java.util.concurrent.atomic.AtomicReference<String>) field.get(pipeline);
+            String lastAddedTaskName = atomicRef.get();
 
             // Assert
             assertEquals(taskName, lastAddedTaskName, "lastAddedTaskName should match the name of the last added task.");

--- a/src/test/java/dev/shaaf/jgraphlet/TaskPipelineVirtualThreadsTest.java
+++ b/src/test/java/dev/shaaf/jgraphlet/TaskPipelineVirtualThreadsTest.java
@@ -1,0 +1,373 @@
+package dev.shaaf.jgraphlet;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for TaskPipeline compatibility with virtual threads.
+ * These tests only run on Java 21+ where virtual threads are available.
+ * The project still targets Java 17 for compatibility.
+ */
+@EnabledForJreRange(min = JRE.JAVA_21)
+class TaskPipelineVirtualThreadsTest {
+
+    /**
+     * Creates a virtual thread executor using reflection to maintain Java 17 compatibility.
+     * This method will only be called when running on Java 21+.
+     */
+    private ExecutorService createVirtualThreadExecutor() {
+        try {
+            // Use reflection to call Executors.newVirtualThreadPerTaskExecutor()
+            // This allows the code to compile on Java 17 but use virtual threads on Java 21+
+            Class<?> executorsClass = Executors.class;
+            Method method = executorsClass.getMethod("newVirtualThreadPerTaskExecutor");
+            return (ExecutorService) method.invoke(null);
+        } catch (Exception e) {
+            // Should not happen as this test only runs on Java 21+
+            throw new RuntimeException("Failed to create virtual thread executor", e);
+        }
+    }
+
+    @Test
+    void shouldWorkWithVirtualThreadExecutor() throws Exception {
+        // Arrange
+        ExecutorService virtualExecutor = createVirtualThreadExecutor();
+        TaskPipeline pipeline = new TaskPipeline(virtualExecutor);
+
+        try {
+            // Create tasks that would benefit from virtual threads (I/O simulation)
+            Task<String, String> fetchTask = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    simulateIOOperation(100); // Simulate I/O
+                    return "fetched: " + input;
+                });
+
+            Task<String, String> processTask = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    simulateIOOperation(50); // Simulate processing
+                    return input.toUpperCase();
+                });
+
+            // Act
+            pipeline.add("fetch", fetchTask)
+                   .then("process", processTask);
+
+            String result = (String) pipeline.run("data").get(5, TimeUnit.SECONDS);
+
+            // Assert
+            assertEquals("FETCHED: DATA", result);
+            System.out.println("✓ Virtual thread executor works with TaskPipeline");
+            
+        } finally {
+            pipeline.shutdown();
+            virtualExecutor.shutdown();
+            assertTrue(virtualExecutor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void shouldHandleHighConcurrencyWithVirtualThreads() throws Exception {
+        // Virtual threads excel at high concurrency scenarios
+        ExecutorService virtualExecutor = createVirtualThreadExecutor();
+        TaskPipeline pipeline = new TaskPipeline(virtualExecutor);
+
+        try {
+            AtomicInteger completedTasks = new AtomicInteger(0);
+
+            // Create a simple I/O-bound task
+            Task<Integer, String> ioTask = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    simulateIOOperation(100); // Simulate blocking I/O
+                    completedTasks.incrementAndGet();
+                    return "Task " + input + " completed";
+                });
+
+            pipeline.add("ioTask", ioTask);
+
+            // Act: Run many tasks concurrently
+            int numTasks = 100;
+            List<CompletableFuture<Object>> futures = new ArrayList<>();
+            
+            Instant start = Instant.now();
+            for (int i = 0; i < numTasks; i++) {
+                futures.add(pipeline.run(i));
+            }
+            
+            // Wait for all to complete
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .get(30, TimeUnit.SECONDS);
+            
+            Duration duration = Duration.between(start, Instant.now());
+
+            // Assert
+            assertEquals(numTasks, completedTasks.get(), 
+                "All tasks should complete");
+            
+            // With virtual threads, 100 tasks with 100ms I/O should complete much faster than sequential
+            // Sequential would take 10 seconds, we should complete in much less
+            assertTrue(duration.getSeconds() < 5, 
+                "High concurrency tasks should complete quickly with virtual threads (took: " + duration.getSeconds() + "s)");
+            
+            // Virtual threads allow many concurrent operations
+            System.out.println("✓ Completed " + numTasks + " tasks in " + duration.toMillis() + "ms with virtual threads");
+            
+        } finally {
+            pipeline.shutdown();
+            virtualExecutor.shutdown();
+            assertTrue(virtualExecutor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void shouldHandleFanInPatternWithVirtualThreads() throws Exception {
+        ExecutorService virtualExecutor = createVirtualThreadExecutor();
+        TaskPipeline pipeline = new TaskPipeline(virtualExecutor);
+
+        try {
+            // Create multiple I/O-bound tasks for fan-in
+            Task<String, String> dbTask = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    simulateIOOperation(150); // Simulate DB query
+                    return "db-data";
+                });
+
+            Task<String, String> apiTask = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    simulateIOOperation(200); // Simulate API call
+                    return "api-data";
+                });
+
+            Task<String, String> cacheTask = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    simulateIOOperation(50); // Simulate cache lookup
+                    return "cache-data";
+                });
+
+            Task<Map<String, Object>, String> aggregateTask = (inputs, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    String db = (String) inputs.get("db");
+                    String api = (String) inputs.get("api");
+                    String cache = (String) inputs.get("cache");
+                    return String.format("Aggregated: [%s, %s, %s]", db, api, cache);
+                });
+
+            // Build fan-in pipeline
+            pipeline.addTask("db", dbTask)
+                   .addTask("api", apiTask)
+                   .addTask("cache", cacheTask)
+                   .addTask("aggregate", aggregateTask);
+
+            pipeline.connect("db", "aggregate")
+                   .connect("api", "aggregate")
+                   .connect("cache", "aggregate");
+
+            // Act
+            Instant start = Instant.now();
+            String result = (String) pipeline.run("input").get(5, TimeUnit.SECONDS);
+            Duration duration = Duration.between(start, Instant.now());
+
+            // Assert
+            assertEquals("Aggregated: [db-data, api-data, cache-data]", result);
+            
+            // Should complete in roughly the time of the slowest task (200ms), not the sum
+            assertTrue(duration.toMillis() < 500, 
+                "Fan-in should execute in parallel with virtual threads");
+            
+            System.out.println("✓ Fan-in pattern completed in " + duration.toMillis() + "ms");
+            
+        } finally {
+            pipeline.shutdown();
+            virtualExecutor.shutdown();
+            assertTrue(virtualExecutor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void shouldNotSufferFromThreadPoolStarvation() throws Exception {
+        // Virtual threads should handle blocking operations without thread pool starvation
+        ExecutorService virtualExecutor = createVirtualThreadExecutor();
+        TaskPipeline pipeline = new TaskPipeline(virtualExecutor);
+
+        try {
+            CountDownLatch allTasksStarted = new CountDownLatch(50);
+            CountDownLatch proceedSignal = new CountDownLatch(1);
+            AtomicInteger startedCount = new AtomicInteger(0);
+
+            // Create a task that blocks until signaled
+            Task<Integer, String> blockingTask = (input, context) ->
+                CompletableFuture.completedFuture(input)
+                    .thenApplyAsync(i -> {
+                        startedCount.incrementAndGet();
+                        allTasksStarted.countDown();
+                        try {
+                            // Block until signaled - this would cause thread pool starvation with platform threads
+                            proceedSignal.await(10, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return "Task " + i + " completed";
+                    }, virtualExecutor); // Use the virtual thread executor explicitly
+
+            pipeline.add("blocking", blockingTask);
+
+            // Act: Start many blocking tasks
+            int taskCount = 50;
+            List<CompletableFuture<Object>> futures = IntStream.range(0, taskCount)
+                .mapToObj(i -> pipeline.run(i))
+                .toList();
+
+            // Wait a bit for tasks to start (more lenient timeout)
+            boolean allStarted = allTasksStarted.await(5, TimeUnit.SECONDS);
+            
+            // Signal all tasks to proceed
+            proceedSignal.countDown();
+            
+            // Wait for completion
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .get(10, TimeUnit.SECONDS);
+
+            // Assert - check that most tasks started (virtual threads should handle many concurrent blocks)
+            int started = startedCount.get();
+            System.out.println("✓ Started " + started + " out of " + taskCount + " blocking tasks with virtual threads");
+            
+            assertTrue(started >= taskCount * 0.8, 
+                "Most tasks should start with virtual threads (started: " + started + " out of " + taskCount + ")");
+            
+        } finally {
+            pipeline.shutdown();
+            virtualExecutor.shutdown();
+            assertTrue(virtualExecutor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void shouldHandleMixedCPUAndIOTasksEfficiently() throws Exception {
+        ExecutorService virtualExecutor = createVirtualThreadExecutor();
+        TaskPipeline pipeline = new TaskPipeline(virtualExecutor);
+
+        try {
+            // I/O-bound task (benefits from virtual threads)
+            Task<String, String> ioTask = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    simulateIOOperation(100);
+                    context.put("ioResult", "io-done");
+                    return input + "-io";
+                });
+
+            // CPU-bound task (doesn't benefit as much from virtual threads)
+            Task<String, Integer> cpuTask = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    // Simulate CPU-intensive work
+                    long sum = 0;
+                    for (int i = 0; i < 1_000_000; i++) {
+                        sum += i;
+                    }
+                    context.put("cpuResult", sum);
+                    return input.length() + (int) (sum % 100);
+                });
+
+            // Another I/O task
+            Task<Integer, String> finalIoTask = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    simulateIOOperation(50);
+                    String ioResult = context.get("ioResult", String.class).orElse("none");
+                    Long cpuResult = context.get("cpuResult", Long.class).orElse(0L);
+                    return String.format("Final: io=%s, cpu=%d, input=%d", ioResult, cpuResult, input);
+                });
+
+            // Build pipeline
+            pipeline.add("io1", ioTask)
+                   .then("cpu", cpuTask)
+                   .then("io2", finalIoTask);
+
+            // Act
+            String result = (String) pipeline.run("test").get(5, TimeUnit.SECONDS);
+
+            // Assert
+            assertNotNull(result);
+            assertTrue(result.contains("io=io-done"));
+            assertTrue(result.contains("cpu="));
+            
+            System.out.println("✓ Mixed CPU and I/O tasks completed successfully");
+            
+        } finally {
+            pipeline.shutdown();
+            virtualExecutor.shutdown();
+            assertTrue(virtualExecutor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void shouldMaintainThreadLocalSafety() throws Exception {
+        // Virtual threads have their own thread locals
+        ExecutorService virtualExecutor = createVirtualThreadExecutor();
+        TaskPipeline pipeline = new TaskPipeline(virtualExecutor);
+
+        try {
+            ThreadLocal<String> threadLocal = new ThreadLocal<>();
+            ConcurrentHashMap<String, String> threadValues = new ConcurrentHashMap<>();
+
+            Task<Integer, String> taskWithThreadLocal = (input, context) ->
+                CompletableFuture.supplyAsync(() -> {
+                    String value = "thread-" + input;
+                    threadLocal.set(value);
+                    
+                    // Simulate some work
+                    simulateIOOperation(10);
+                    
+                    // Verify thread local is maintained
+                    String retrieved = threadLocal.get();
+                    threadValues.put(value, retrieved);
+                    
+                    return retrieved;
+                });
+
+            pipeline.add("threadLocalTask", taskWithThreadLocal);
+
+            // Run multiple tasks concurrently
+            List<CompletableFuture<Object>> futures = IntStream.range(0, 50)
+                .mapToObj(pipeline::run)
+                .toList();
+
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .get(5, TimeUnit.SECONDS);
+
+            // Assert - each virtual thread maintained its own thread local
+            assertEquals(50, threadValues.size());
+            threadValues.forEach((key, value) -> 
+                assertEquals(key, value, "Thread local should be maintained per virtual thread"));
+            
+            System.out.println("✓ Thread locals maintained correctly across " + threadValues.size() + " virtual threads");
+            
+        } finally {
+            pipeline.shutdown();
+            virtualExecutor.shutdown();
+            assertTrue(virtualExecutor.awaitTermination(5, TimeUnit.SECONDS));
+        }
+    }
+
+    /**
+     * Simulates an I/O operation that blocks the thread.
+     * Virtual threads handle blocking operations efficiently.
+     */
+    private void simulateIOOperation(int milliseconds) {
+        try {
+            Thread.sleep(milliseconds);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
Summary of Changes

- Virtual threads support (Java 21+): Added TaskPipelineVirtualThreadsTest covering 6 scenarios (compatibility, concurrency, fan-in, starvation, mixed workloads, thread-local safety) using reflection for Java 17 compatibility.
- Executor shutdown fix: Introduced timeout + awaitTermination (30s graceful, 10s forced) to prevent resource leaks; added logging and tests.
- Performance optimization: Replaced findPredecessorsFor O(n*m) lookup with reverse adjacency map for O(1) performance; added benchmarks and tests.